### PR TITLE
Document basic management of community projects

### DIFF
--- a/MEETING.md
+++ b/MEETING.md
@@ -1,0 +1,59 @@
+# Prometheus & The Ecosystem Community Meeting
+
+We have PUBLIC and RECORDED monthly meeting every first Wednesday of the month, on odd months 9:00 am UTC([Time zone converter](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=UTC%20(Coordinated%20Universal%20Time)&)), on even months 5:00 pm UTC([Time zone converter](https://www.thetimezoneconverter.com/?t=5%3A00%20pm&tz=UTC%20(Coordinated%20Universal%20Time)&)).
+
+See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=o4g18inl0mghikksvgtd6nspms%40group.calendar.google.com), or paste this [iCal url](https://calendar.google.com/calendar/ical/o4g18inl0mghikksvgtd6nspms%40group.calendar.google.com/public/basic.ics) into any [iCal client](https://en.wikipedia.org/wiki/ICalendar). Do NOT copy the meetings over to a your personal calendar, you will miss meeting updates. Instead use your client's calendaring feature to say you are attending the meeting so that any changes made to meetings will be reflected on your personal calendar. 
+
+All meetings are archived on the [Youtube Channel](https://www.youtube.com/channel/UC4pLFely0-Odea4B2NL1nWA).
+
+Quick links:
+
+- [Agenda document](https://bit.ly/prometheus-community-agenda)
+- [9 AM UTC Zoom meeting link](https://zoom.us/j/639056489)
+- [5 PM UTC Zoom meeting link](https://zoom.us/j/906107777)
+
+## Purpose
+
+The Prometheus & The Ecosystem community meeting is intended to provide a holistic overview of community activities, critical release information, and governance updates. 
+It also provides a forum for discussion of project-level concerns that might need a wider audience.
+
+## Code Of Conduct
+
+The meeting follows the [Prometheus Code of Conduct](https://github.com/prometheus/prometheus/blob/main/CODE_OF_CONDUCT.md). If you notice a violation of the Code of Conduct, reach out to Mishi Choudhary at [mishi@linux.com](mailto:mishi@linux.com).
+
+## Meeting Agenda
+
+If you have a topic you'd like to present or would like to see discussed,
+please propose a specific date on the [Prometheus & The Ecosystem Community Meeting Agenda](https://bit.ly/prometheus-community-agenda).
+
+General speaking the meeting is structured as follows:
+
+- Introduction by Host (~3 minutes)
+- Prometheus Updates & Announcements (~10 minutes)
+- (Optional) Ecosystem Updates & Announcements (~10 minutes)
+- Questions (~5 minutes)
+
+## Updates & Announcements
+
+The first 10 minutes of a meeting are dedicated to Prometheus Updates & Announcements. The next 10 minutes are dedicated to Ecosystem Updates & Announcements. These announcements are noted at the top of the community document. There is a hard stop of the announcements at 10 minutes, with up to 5 more minutes for questions.
+
+If you want to announce something during the time allocated for announcements, contact the organizers. They will get back to you.
+
+Announcements submissions MUST follow the requirements listed below. 
+
+### Requirements
+
+This meeting has a large number of attendees. 
+Out of respect for their time, we ask that you be fully prepared for your announcement. Make sure slides are clear if applicable, and the link to them is posted in the meeting agenda. 
+
+- Your announcement should provide clear, valuable information to the community without being commercial in nature. Typical sales pitches are not permitted, and could potentially alienate your audience. 
+- You are required to show up 10 minutes before the meeting to verify your audio and screensharing capabilities with the hosts. If you cannot make and keep this commitment, you will not be allowed to proceed with your announcement until such time you can.
+- You also required to commit to being available the week before your announcement date in case there is an issue with that week's announcement.
+- The use of a headset or other high-quality audio equipment is strongly encouraged. Typing on a laptop while using the system microphone is distracting, so please insulate your microphone from key noises.
+- Ensure you are presenting from a quiet environment.
+- If you run out of time while performing your announcement, you may ask the audience if they would like a follow-up at a subsequent meeting. If there is enthusiastic support, the community team will help schedule a continuation.
+
+## Archives
+
+The document gets slow as we add notes, so it is archived regularly into another document.
+

--- a/README.md
+++ b/README.md
@@ -1,59 +1,11 @@
-# Prometheus & The Ecosystem Community Meeting
+# Prometheus Community
 
-We have PUBLIC and RECORDED monthly meeting every first Wednesday of the month, on odd months 9:00 am UTC([Time zone converter](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=UTC%20(Coordinated%20Universal%20Time)&)), on even months 5:00 pm UTC([Time zone converter](https://www.thetimezoneconverter.com/?t=5%3A00%20pm&tz=UTC%20(Coordinated%20Universal%20Time)&)).
+The [prometheus-community organization](https://github.com/prometheus-community) collects resources and projects outside of, but associated with, the [Prometheus project](https://prometheus.io).
 
-See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=o4g18inl0mghikksvgtd6nspms%40group.calendar.google.com), or paste this [iCal url](https://calendar.google.com/calendar/ical/o4g18inl0mghikksvgtd6nspms%40group.calendar.google.com/public/basic.ics) into any [iCal client](https://en.wikipedia.org/wiki/ICalendar). Do NOT copy the meetings over to a your personal calendar, you will miss meeting updates. Instead use your client's calendaring feature to say you are attending the meeting so that any changes made to meetings will be reflected on your personal calendar. 
+## Prometheus & The Ecosystem Community Meeting
 
-All meetings are archived on the [Youtube Channel](https://www.youtube.com/channel/UC4pLFely0-Odea4B2NL1nWA).
+See [MEETING.md](MEETING.md) for information on the Prometheus & The Ecosystem Community Meeting.
 
-Quick links:
+## Community Repositories
 
-- [Agenda document](https://bit.ly/prometheus-community-agenda)
-- [9 AM UTC Zoom meeting link](https://zoom.us/j/639056489)
-- [5 PM UTC Zoom meeting link](https://zoom.us/j/906107777)
-
-## Purpose
-
-The Prometheus & The Ecosystem community meeting is intended to provide a holistic overview of community activities, critical release information, and governance updates. 
-It also provides a forum for discussion of project-level concerns that might need a wider audience.
-
-## Code Of Conduct
-
-The meeting follows the [Prometheus Code of Conduct](https://github.com/prometheus/prometheus/blob/main/CODE_OF_CONDUCT.md). If you notice a violation of the Code of Conduct, reach out to Mishi Choudhary at [mishi@linux.com](mailto:mishi@linux.com).
-
-## Meeting Agenda
-
-If you have a topic you'd like to present or would like to see discussed,
-please propose a specific date on the [Prometheus & The Ecosystem Community Meeting Agenda](https://bit.ly/prometheus-community-agenda).
-
-General speaking the meeting is structured as follows:
-
-- Introduction by Host (~3 minutes)
-- Prometheus Updates & Announcements (~10 minutes)
-- (Optional) Ecosystem Updates & Announcements (~10 minutes)
-- Questions (~5 minutes)
-
-## Updates & Announcements
-
-The first 10 minutes of a meeting are dedicated to Prometheus Updates & Announcements. The next 10 minutes are dedicated to Ecosystem Updates & Announcements. These announcements are noted at the top of the community document. There is a hard stop of the announcements at 10 minutes, with up to 5 more minutes for questions.
-
-If you want to announce something during the time allocated for announcements, contact the organizers. They will get back to you.
-
-Announcements submissions MUST follow the requirements listed below. 
-
-### Requirements
-
-This meeting has a large number of attendees. 
-Out of respect for their time, we ask that you be fully prepared for your announcement. Make sure slides are clear if applicable, and the link to them is posted in the meeting agenda. 
-
-- Your announcement should provide clear, valuable information to the community without being commercial in nature. Typical sales pitches are not permitted, and could potentially alienate your audience. 
-- You are required to show up 10 minutes before the meeting to verify your audio and screensharing capabilities with the hosts. If you cannot make and keep this commitment, you will not be allowed to proceed with your announcement until such time you can.
-- You also required to commit to being available the week before your announcement date in case there is an issue with that week's announcement.
-- The use of a headset or other high-quality audio equipment is strongly encouraged. Typing on a laptop while using the system microphone is distracting, so please insulate your microphone from key noises.
-- Ensure you are presenting from a quiet environment.
-- If you run out of time while performing your announcement, you may ask the audience if they would like a follow-up at a subsequent meeting. If there is enthusiastic support, the community team will help schedule a continuation.
-
-## Archives
-
-The document gets slow as we add notes, so it is archived regularly into another document.
-
+See [REPOSITORIES.md](REPOSITORIES.md) for information on the creation and management of repositories in this organization.

--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -1,0 +1,32 @@
+# Community Repositories
+
+The [prometheus-community organization](https://github.com/prometheus-community) collects projects associated with [Prometheus](https://prometheus.io) that are not part of the [prometheus organization](https://github.com/prometheus) itself.
+
+Support for community projects is best-effort on the part of the Prometheus project.
+Each project must have a sponsor from the [Prometheus team](https://prometheus.io/governance/#team-members).
+
+## For community members
+
+To propose adding a new repository to the prometheus-community organization, [open an issue on this repository](https://github.com/prometheus-community/community/issues).
+
+## For sponsors
+
+### Creating a new repository
+
+1. Comment on the issue that you are willing to sponsor this repository.
+1. Create a [team](https://github.com/orgs/prometheus-community/teams) and add the maintainers for the new repository, unless there is already an appropriate team.
+1. Create the repository.
+1. In the repository Settings -> Collaborators and Teams, add the team that should manage the repository, as Admin.
+1. Subscribe to notifications for the repository.
+
+### Importing an existing repository
+
+1. Comment on the issue that you are willing to sponsor this repository.
+1. Create a [team](https://github.com/orgs/prometheus-community/teams) and add the maintainers for the new repository, unless there is already an appropriate team.
+1. Transfer the repository.
+    * If you have owner rights on both sides:
+        1. Transfer the repository directly.
+    * If you do not have owner rights on the original repository:
+        1. Ask the owner of the existing repository to initiate the transfer into the prometheus-community organization.
+        1. Accept the transfer.
+1. Subscribe to notifications for the repository.

--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -11,14 +11,6 @@ To propose adding a new repository to the prometheus-community organization, [op
 
 ## For sponsors
 
-### Creating a new repository
-
-1. Comment on the issue that you are willing to sponsor this repository.
-1. Create a [team](https://github.com/orgs/prometheus-community/teams) and add the maintainers for the new repository, unless there is already an appropriate team.
-1. Create the repository.
-1. In the repository Settings -> Collaborators and Teams, add the team that should manage the repository, as Admin.
-1. Subscribe to notifications for the repository.
-
 ### Importing an existing repository
 
 1. Comment on the issue that you are willing to sponsor this repository.
@@ -29,4 +21,12 @@ To propose adding a new repository to the prometheus-community organization, [op
     * If you do not have owner rights on the original repository:
         1. Ask the owner of the existing repository to initiate the transfer into the prometheus-community organization.
         1. Accept the transfer.
+1. Subscribe to notifications for the repository.
+
+### Creating a new repository
+
+1. Comment on the issue that you are willing to sponsor this repository.
+1. Create a [team](https://github.com/orgs/prometheus-community/teams) and add the maintainers for the new repository, unless there is already an appropriate team.
+1. Create the repository.
+1. In the repository Settings -> Collaborators and Teams, add the team that should manage the repository, as Admin.
 1. Subscribe to notifications for the repository.


### PR DESCRIPTION
Since this repository has a wider scope, move the Prometheus & The Ecosystem Community Meeting document to a separate file.

Add basic documentation on the practices around community projects.

I was trying to figure out how to handle #43 but had to ask @SuperQ.